### PR TITLE
fix. Correct arena type to be 3v3

### DIFF
--- a/src/solo3v3.h
+++ b/src/solo3v3.h
@@ -23,11 +23,11 @@
 #include "BattlegroundMgr.h"
 #include "Player.h"
 
-constexpr uint32 ARENA_TEAM_SOLO_3v3 = 5;
-constexpr uint32 ARENA_TYPE_3v3_SOLO = 5;
-constexpr uint32 ARENA_SLOT_SOLO_3v3 = 2;
-constexpr uint32 BATTLEGROUND_QUEUE_3v3_SOLO = 10;
-constexpr BattlegroundQueueTypeId bgQueueTypeId = (BattlegroundQueueTypeId)((int)BATTLEGROUND_QUEUE_5v5);
+constexpr uint32 ARENA_TEAM_SOLO_3v3 = 3;
+constexpr uint32 ARENA_TYPE_3v3_SOLO = 3;
+constexpr uint32 ARENA_SLOT_SOLO_3v3 = 3;
+constexpr uint32 BATTLEGROUND_QUEUE_3v3_SOLO = 11;
+constexpr BattlegroundQueueTypeId bgQueueTypeId = (BattlegroundQueueTypeId)((int)BATTLEGROUND_QUEUE_3v3);
 
 const uint32 FORBIDDEN_TALENTS_IN_1V1_ARENA[] =
 {


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Correct the type of arena, so that it is created in the database, type 3 and also, so that in the crystals, when entering the arena, the maximum number appears, 6 members.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-arena-3v3-solo-queue/issues/2

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Score with 2 accounts, enter the arena, and check that the crystals appear as a maximum amount of 6 players.
2. Also the arena icon, in the minimap area, should say 3v3

## Screenshots

![WoWScrnShot_032224_235858](https://github.com/pangolp/mod-arena-3v3-solo-queue/assets/2810187/faaf6f6d-9106-487c-a82f-302252eb790d)

![WoWScrnShot_032224_235939](https://github.com/pangolp/mod-arena-3v3-solo-queue/assets/2810187/6529a9db-47c2-46ef-9f80-bc602de2e13a)

![WoWScrnShot_032224_235946](https://github.com/pangolp/mod-arena-3v3-solo-queue/assets/2810187/9c239e11-eac1-4902-bb65-1330f919214d)