### PR TITLE
fix. Use configuration variable for multiple sand points

### DIFF
--- a/src/solo3v3_sc.cpp
+++ b/src/solo3v3_sc.cpp
@@ -470,7 +470,7 @@ void Team3v3arena::OnGetArenaPoints(ArenaTeam* at, float& points)
 {
     if (at->GetType() == ARENA_TEAM_SOLO_3v3)
     {
-        points *= 0.64f;
+        points *= sConfigMgr->GetOption<float>("Solo.3v3.ArenaPointsMulti", 0.8f);
     }
 }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Instead of using the value statically, we have a configuration variable, which we can use and change as we like.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes https://github.com/azerothcore/mod-arena-3v3-solo-queue/issues/4

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Change the values, to obtain different results. Previously, it was 0.64, so now, since it is 0.8, there should be a change.